### PR TITLE
Fix case statement syntax for 1.9

### DIFF
--- a/normarc2rdf.rb
+++ b/normarc2rdf.rb
@@ -22,10 +22,10 @@ def usage(s)
 end
 
 loop { case ARGV[0]
-    when '-i':  ARGV.shift; $input_file  = ARGV.shift
-    when '-o':  ARGV.shift; $output_file = ARGV.shift
-    when '-r':  ARGV.shift; $recordlimit = ARGV.shift.to_i # force integer
-    when /^-/:  usage("Unknown option: #{ARGV[0].inspect}")
+    when '-i' then  ARGV.shift; $input_file  = ARGV.shift
+    when '-o' then  ARGV.shift; $output_file = ARGV.shift
+    when '-r' then  ARGV.shift; $recordlimit = ARGV.shift.to_i # force integer
+    when /^-/ then  usage("Unknown option: #{ARGV[0].inspect}")
     else 
       if !$input_file || !$output_file then usage("Missing argument!\n") end
     break


### PR DESCRIPTION
The `when case: result` syntax you use in normarc2rdf.rb doesn't work in Ruby 1.9 (only 1.8). The 1.9 one-liner equivalent, also compatible with 1.8, is `when case then result`. I've tested and, with that change, everything seems to work as expected in 1.9. And much faster! For your sample dataset, here's a speed comparison:

time ruby normarc2rdf.rb -i hamsun_fikset.mrc -o output-192.rdf
converted records: 842

real0m33.219s
user0m32.996s
sys0m0.248s

time ruby normarc2rdf.rb -i hamsun_fikset.mrc -o output-187.rdf
converted records: 842

real4m59.133s
user4m58.927s
sys0m0.192s
