### PR TITLE
Resumption tokens, debug output

### DIFF
--- a/lib/sparql_update.rb
+++ b/lib/sparql_update.rb
@@ -15,6 +15,7 @@ module RestClient
 #{@delete_statement} <#{@default_graph}> { <#{resource}> ?p ?o }
 WHERE { GRAPH <#{@default_graph}> { <#{resource}> ?p ?o } }
 EOQ
+    puts query if $debug
     resource = RestClient::Resource.new(@endpoint, :user => @username, :password => @password)
     resource.post :query => query, :key => @key
   end
@@ -32,6 +33,7 @@ EOQ
     query = <<-EOQ
 #{@insert_statement} <#{@default_graph}> { #{ntriples.join} }
 EOQ
+    puts query if $debug
     resource = RestClient::Resource.new(@endpoint, :user => @username, :password => @password)
     resource.post :query => query, :key => @key
   end  

--- a/oai_harvester.rb
+++ b/oai_harvester.rb
@@ -47,7 +47,21 @@ end; }
 
 @@yamltags = MAPPINGFILE['tags']
 client = OAI::Client.new(CONFIG['oai']['repository_url'], {:redirects=>CONFIG['oai']['follow_redirects'], :parser=>CONFIG['oai']['parser'], :timeout=>CONFIG['oai']['timeout'], :debug=>true})
-oairecords = client.list_records :metadata_prefix =>CONFIG['oai']['format'], :from => $fromdate, :until => Date.today.to_s
+response = client.list_records :metadata_prefix =>CONFIG['oai']['format'], :from => $fromdate, :until => Date.today.to_s
+
+# Pick out the first records
+oairecords = Array.new
+response.each do | oairecord |
+  oairecords << oairecord
+end
+
+# If we got a resumption token we need to loop until we have all the records
+while(response.resumption_token and not response.resumption_token.empty?)
+  response = client.list_records(:resumption_token => response.resumption_token)
+  response.each do | oairecord |
+    oairecords << oairecord
+  end
+end
 
 i = 0
 

--- a/oai_harvester.rb
+++ b/oai_harvester.rb
@@ -32,6 +32,7 @@ $fromdate = Date.today.prev_day.to_s
 loop { case ARGV[0]
     when '-f' then  ARGV.shift; $fromdate = ARGV.shift
     when '-r' then  ARGV.shift; $recordlimit = ARGV.shift.to_i # force integer
+    when '-d' then  ARGV.shift; $debug = true
     when /^-/ then  usage("Unknown option: #{ARGV[0].inspect}")
     else 
     break


### PR DESCRIPTION
I think i figured out how to support resumption tokens. It works with Koha, at least. 

Printing triples before sending them to the triplestore seems like a handy way to see what is actually going on. 
